### PR TITLE
Add in functionality to take file from synapse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.nextflow/
+work/
+.nextflow.log*
+test-outputs/

--- a/README.md
+++ b/README.md
@@ -15,13 +15,27 @@ A Docker container ([adamjtaylor/htan-artist](https://hub.docker.com/repository/
 ## Example usage
 
 ```
-nextflow run adamjtaylor/htan-artist --input <path-to-image> --outdir <output-directory> --all
+nextflow run adamjtaylor/htan-artist --input_path <path-to-image> --outdir <output-directory> --all
 ```
 
 ## Options
 
-`--miniature` - Renders a thumbnail image using [Miniature](https://github.com/adamjtaylor/miniature)  
-`--metadata` - Extract tags from the image header and save to a json file
+`--outdir` - output directory. Default: `.`
+`--minerva`: Renders an [Auto-Minerva](https://github.com/jmuhlich/auto-minerva) story
+`--miniature` - Renders a thumbnail image using [Miniature](https://github.com/adamjtaylor/miniature) 
+`--metadata` -  Extract headers from the image and save as a json
+`--all` - set `--minerva` `--miniature` and `--metadata` 
+`--he` - Use an unscaled scene for Minerva story and thumbnail generation. Suitable for H&E images
+`--input_csv` - Path to a csv with a file path, uid, or synapseID per row
+`--input_synid` - A synapse ID
+`--input_path` - The path to a file. Can take wildcards
+`--watch_path` - A path to watch for files that are created or modified
+`--watch_csv` - A path to a csv to watch for if it is modified
+`--echo` - Echo outputs
+`--keepBg` - Keep the background in thumbnails
+`--level` - the pyramid level used in thumbnauls, Default: `-1` (highest)
+`--bioformats2ometiff` - Convert images to ome-tiff. Default: `true`
+`--synapseconfig` - Path to a synapseConfig file. Required for Synapse authentication
 
 ## Example flow diagram:
 

--- a/README.md
+++ b/README.md
@@ -20,22 +20,22 @@ nextflow run adamjtaylor/htan-artist --input_path <path-to-image> --outdir <outp
 
 ## Options
 
-`--outdir` - output directory. Default: `.`
-`--minerva`: Renders an [Auto-Minerva](https://github.com/jmuhlich/auto-minerva) story
-`--miniature` - Renders a thumbnail image using [Miniature](https://github.com/adamjtaylor/miniature) 
-`--metadata` -  Extract headers from the image and save as a json
-`--all` - set `--minerva` `--miniature` and `--metadata` 
-`--he` - Use an unscaled scene for Minerva story and thumbnail generation. Suitable for H&E images
-`--input_csv` - Path to a csv with a file path, uid, or synapseID per row
-`--input_synid` - A synapse ID
-`--input_path` - The path to a file. Can take wildcards
-`--watch_path` - A path to watch for files that are created or modified
-`--watch_csv` - A path to a csv to watch for if it is modified
-`--echo` - Echo outputs
-`--keepBg` - Keep the background in thumbnails
-`--level` - the pyramid level used in thumbnauls, Default: `-1` (highest)
-`--bioformats2ometiff` - Convert images to ome-tiff. Default: `true`
-`--synapseconfig` - Path to a synapseConfig file. Required for Synapse authentication
+`--outdir` - output directory. Default: `.`  
+`--minerva`: Renders an [Auto-Minerva](https://github.com/jmuhlich/auto-minerva) story  
+`--miniature` - Renders a thumbnail image using [Miniature](https://github.com/adamjtaylor/miniature)   
+`--metadata` -  Extract headers from the image and save as a json  
+`--all` - set `--minerva` `--miniature` and `--metadata`   
+`--he` - Use an unscaled scene for Minerva story and thumbnail generation. Suitable for H&E images  
+`--input_csv` - Path to a csv with a file path, uid, or synapseID per row  
+`--input_synid` - A synapse ID  
+`--input_path` - The path to a file. Can take wildcards  
+`--watch_path` - A path to watch for files that are created or modified  
+`--watch_csv` - A path to a csv to watch for if it is modified  
+`--echo` - Echo outputs  
+`--keepBg` - Keep the background in thumbnails  
+`--level` - the pyramid level used in thumbnauls, Default: `-1` (highest)  
+`--bioformats2ometiff` - Convert images to ome-tiff. Default: `true`  
+`--synapseconfig` - Path to a synapseConfig file. Required for Synapse authentication  
 
 ## Example flow diagram:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN source /venv/bin/activate && \
     wget https://gist.githubusercontent.com/adamjtaylor/964e206bf1e6f302f6e512082e953193/raw/0acdea0736a027a260a0bb598f619552ff106758/index.html && \
     pip install git+https://github.com/labsyspharm/minerva-lib-python@master#egg=minerva-lib && \
     pip install openslide-python && \
-    pip install opencv-python-headless
+    pip install opencv-python-headless \
     pip install synapseclient
 
 ENV VIRTUAL_ENV=/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,7 @@ RUN source /venv/bin/activate && \
     pip install git+https://github.com/labsyspharm/minerva-lib-python@master#egg=minerva-lib && \
     pip install openslide-python && \
     pip install opencv-python-headless
+    pip install synapseclient
 
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -29,4 +29,3 @@ dependencies:
   - raw2ometiff
   - ome-types
   - pip
-  - synapseclient

--- a/docker/environment.yml
+++ b/docker/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - ome
   - fastai
+  - bioconda
 dependencies:
   - numpy
   - Pillow
@@ -28,3 +29,4 @@ dependencies:
   - raw2ometiff
   - ome-types
   - pip
+  - synapseclient

--- a/main.nf
+++ b/main.nf
@@ -13,6 +13,7 @@ params.bucket = false
 params.level = -1
 params.bioformats2ometiff = true
 params.synapseconfig = false
+params.watch_path = false
 
 heStory = 'https://gist.githubusercontent.com/adamjtaylor/3494d806563d71c34c3ab45d75794dde/raw/d72e922bc8be3298ebe8717ad2b95eef26e0837b/unscaled.story.json'
 heScript = 'https://gist.githubusercontent.com/adamjtaylor/bbadf5aa4beef9aa1d1a50d76e2c5bec/raw/1f6e79ab94419e27988777343fa2c345a18c5b1b/fix_he_exhibit.py'
@@ -46,9 +47,18 @@ if (params.input =~ /.+\.csv$/) {
     .into {input_ch; view_ch}
 }
 
+if (params.watch_file =~ /.+\.csv$/) {
+  Channel
+      .watchPath(params.watch_path, 'create,modify')
+      .splitCsv(header:false, sep:'', strip:true)
+      .map { it[0] }
+      .unique()
+      .into { watch_ch }
+
 if (params.echo) { view_ch.view() }
 
 input_ch
+  .mix(watch_ch)
   .branch {
       syn: it =~ /^syn\d{8}/
       other: true

--- a/main.nf
+++ b/main.nf
@@ -20,7 +20,7 @@ params.watch_file = false
 
 heStory = 'https://gist.githubusercontent.com/adamjtaylor/3494d806563d71c34c3ab45d75794dde/raw/d72e922bc8be3298ebe8717ad2b95eef26e0837b/unscaled.story.json'
 heScript = 'https://gist.githubusercontent.com/adamjtaylor/bbadf5aa4beef9aa1d1a50d76e2c5bec/raw/1f6e79ab94419e27988777343fa2c345a18c5b1b/fix_he_exhibit.py'
-minerva_description_script = 'https://gist.githubusercontent.com/adamjtaylor/e51873a801fee39f1f1efa978e2b5e44/raw/d5e836463ed9ff8510f087d1509d6a5395d1da26/inject_description.py'
+minerva_description_script = 'https://gist.githubusercontent.com/adamjtaylor/e51873a801fee39f1f1efa978e2b5e44/raw/c03d0e09ec58e4c391f5ce4ca4183abca790f2a2/inject_description.py'
 
 if (params.synapseconfig!= false){
   synapseconfig = file(params.synapseconfig)

--- a/main.nf
+++ b/main.nf
@@ -13,6 +13,7 @@ params.keepBg = false
 params.bucket = false
 params.level = -1
 params.bioformats2ometiff = true
+params.synapse = false
 
 heStory = 'https://gist.githubusercontent.com/adamjtaylor/3494d806563d71c34c3ab45d75794dde/raw/d72e922bc8be3298ebe8717ad2b95eef26e0837b/unscaled.story.json'
 heScript = 'https://gist.githubusercontent.com/adamjtaylor/bbadf5aa4beef9aa1d1a50d76e2c5bec/raw/1f6e79ab94419e27988777343fa2c345a18c5b1b/fix_he_exhibit.py'
@@ -40,10 +41,24 @@ if (params.input =~ /.+\.csv$/) {
 } else {
     Channel
     .fromPath(params.input)
-    .into {input_ch_ome; input_ch_notome; view_ch}
+    .into {input_ch_ome; view_ch}
 }
 
 if (params.echo) { view_ch.view() }
+
+process synapse_get {
+  when: params.synapse
+  input:
+    val from input_ch_ome2
+    file synapseconfig from file(params.synapseconfig)
+  output:
+    file '*' into input_ch_ome
+  script:
+    """
+    echo "synapse -c $synapseconfig get $synid"
+    synapse -c $synapseconfig get $synid
+    """
+}
 
 input_ch_ome
   .branch {

--- a/main.nf
+++ b/main.nf
@@ -35,12 +35,7 @@ if (params.input =~ /.+\.csv$/) {
       .splitCsv(header:false, sep:'', strip:true)
       .map { it[0] }
       .unique()
-      .map { it -> file(it) }
       .into { input_ch; view_ch }
-} else if (params.synapseconfig) {
-  Channel
-    .from(params.input)
-    .into {input_ch; view_ch}
 } else {
     Channel
     .fromPath(params.input)
@@ -52,7 +47,9 @@ if (params.echo) { view_ch.view() }
 if (params.synapseconfig) {
   input_ch.set{synapse_ch}
 } else {
-  input_ch.set{file_ch}
+  input_ch
+    .map { it -> file(it) }
+    .set{file_ch}
 }
 
 process synapse_get {

--- a/main.nf
+++ b/main.nf
@@ -36,6 +36,10 @@ if (params.input =~ /.+\.csv$/) {
       .map { it[0] }
       .unique()
       .into { input_ch; view_ch }
+} else if (params.synapseconfig) {
+    Channel
+    .of(params.input)
+    .into {input_ch; view_ch}
 } else {
     Channel
     .fromPath(params.input)


### PR DESCRIPTION
Significantly rewrites the inputs 
Now takes one or more of

`--input_csv` - Path to a csv with a file path, uid, or synapseID per row
`--input_synid` - A synapse ID
`--input_path` - The path to a file. Can take wildcards
`--watch_path` - A path to watch for files that are created or modified
`--watch_csv` - A path to a csv to watch for if it is modified

Where a synapse id is given the file is staged from synapse and annotations saved as a json file
Additionally the outputs are changed to be in the format

`outdir/workflow_name/synid/workflow_name/headers.json`
`outdir/workflow_name/synid/workflow_name/thumbnail.png`
`outdir/workflow_name/synid/workflow_name/minerva/`

This enables a direct copy of a dir into the assets bucket