### PR TITLE
Provide synapse auth token in secret

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -15,16 +15,11 @@ params.echo = false
 params.keepBg = false
 params.level = -1
 params.bioformats2ometiff = true
-params.synapseconfig = false
 params.watch_file = false
 
 heStory = 'https://gist.githubusercontent.com/adamjtaylor/3494d806563d71c34c3ab45d75794dde/raw/d72e922bc8be3298ebe8717ad2b95eef26e0837b/unscaled.story.json'
 heScript = 'https://gist.githubusercontent.com/adamjtaylor/bbadf5aa4beef9aa1d1a50d76e2c5bec/raw/1f6e79ab94419e27988777343fa2c345a18c5b1b/fix_he_exhibit.py'
 minerva_description_script = 'https://gist.githubusercontent.com/adamjtaylor/e51873a801fee39f1f1efa978e2b5e44/raw/c03d0e09ec58e4c391f5ce4ca4183abca790f2a2/inject_description.py'
-
-if (params.synapseconfig != false){
-  synapseconfig = file(params.synapseconfig)
-}
 
 if(params.keepBg == false) { 
   remove_bg = true
@@ -218,7 +213,6 @@ process render_pyramid{
     params.minerva == true || params.all == true
   input:
     set synid, file(story), file(ome) from ome_pyramid_ch
-    file synapseconfig from synapseconfig
   output:
     file 'minerva'
   stub:
@@ -235,14 +229,14 @@ process render_pyramid{
     wget -O fix_he_exhibit.py $heScript
     python3 fix_he_exhibit.py minerva/exhibit.json
     wget -O inject_description.py $minerva_description_script
-    python3 inject_description.py minerva/exhibit.json -synid$synid --synapseconfig $synapseconfig
+    python3 inject_description.py minerva/exhibit.json -synid$synid
     """
   else
     """
     python3  /minerva-author/src/save_exhibit_pyramid.py $ome $story 'minerva'
     cp /index.html minerva
     wget -O inject_description.py $minerva_description_script
-    python3 inject_description.py minerva/exhibit.json --synid $synid --output minerva/exhibit.json --synapseconfig $synapseconfig
+    python3 inject_description.py minerva/exhibit.json --synid $synid --output minerva/exhibit.json
   """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,7 +21,3 @@ process {
 }
 
 docker.enabled = true
-
-# env {
-#   NXF_OPTS = '-Xms512m -Xmx4g'
-# }


### PR DESCRIPTION
Changes to use the `SYNAPSE_AUTH_TOKEN` secret rather than a provided `.synapseConfig` file in params.